### PR TITLE
docs(README): fix link to API documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ In order to use this library, you first need to go through the following steps:
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud Media Translation API.:  https://cloud.google.com/memorystore/docs/mediatranslation
+.. _Enable the Cloud Media Translation API.:  https://cloud.google.com/translate/media/docs
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Python Client for Cloud Media Translation
    :target: https://pypi.org/project/google-cloud-media-translation/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-media-translation.svg
    :target: https://pypi.org/project/google-cloud-media-translation/
-.. _Cloud Media Translation API: https://cloud.google.com/docs/media-translation/
+.. _Cloud Media Translation API: https://cloud.google.com/translate/media/docs
 .. _Client Library Documentation: https://googleapis.dev/python/mediatranslation/latest
 .. _Product Documentation:  https://cloud.google.com/media-translation/
 
@@ -78,5 +78,5 @@ Next Steps
 -  View this `repository’s main README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud Media Translation API Product documentation:  https://cloud.google.com/docs/media-translation
+.. _Cloud Media Translation API Product documentation:  https://cloud.google.com/translate/media/docs
 .. _repository’s main README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst


### PR DESCRIPTION
Previous link was a 404. I suppose you could either link to the main project page or the docs, but given that the main product page is linked to already as the "Product Documentation", I assume the intent for this link is to go to the docs themselves.

This is a trivial change so the template checks don't really apply.
