### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "mediatranslation",
     "name_pretty": "Media Translation",
     "product_documentation": "https://cloud.google.com/media-translation",
-    "client_documentation": "https://googleapis.dev/python/mediatranslation/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/mediatranslation/latest",
     "issue_tracker": "",
     "release_level": "beta",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Media Translation
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-media-translation.svg
    :target: https://pypi.org/project/google-cloud-media-translation/
 .. _Cloud Media Translation API: https://cloud.google.com/translate/media/docs
-.. _Client Library Documentation: https://googleapis.dev/python/mediatranslation/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/mediatranslation/latest
 .. _Product Documentation:  https://cloud.google.com/media-translation/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.